### PR TITLE
feat: make account confirmation opt-in, add console mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,33 @@ mvnDeps = Seq(
 )
 ```
 
+### Account confirmation is opt-in
+
+Out of the box Apollo needs no mail provider: registration signs the user
+straight in, and `MailService.console` prints password-reset codes to the
+server log instead of sending e-mail.
+
+```scala
+given Console[F] = Console.make[F]
+
+ApolloServices[F, User, UserId, String](
+  user = DoobieUserService[F, User, UserId](xa),
+  mail = MailService.console[F],
+  session = DoobieSessionService[F, User, UserId](xa),
+  reset = DoobieResetService[F, User, UserId](xa)
+)
+```
+
+To require e-mail confirmation before login, provide the service and a real
+mailer:
+
+```scala
+  mail = mailgunMailService, // your MailService[F, E, Unit]
+  confirmation = Some(DoobieConfirmationService[F, User, UserId](xa))
+```
+
+When `confirmation` is `None`, the `/confirm` route is not served.
+
 ## Getting Started
 
 First, pull down Apollo and add it to your local ivy cache:

--- a/apollo-core/src/io/github/joshuakfarrar/apollo/core/MailService.scala
+++ b/apollo-core/src/io/github/joshuakfarrar/apollo/core/MailService.scala
@@ -1,9 +1,27 @@
 package io.github.joshuakfarrar.apollo.core
 
+import cats.Applicative
 import cats.data.EitherT
+import cats.effect.std.Console
 
 trait MailService[F[_], Msg, Res] {
   def confirmationEmail(to: String, code: String): Msg
   def resetEmail(to: String, code: String): Msg
   def send(msg: Msg): EitherT[F, Throwable, Res]
 }
+
+object MailService:
+  /** Prints mail to the console instead of sending it, so the reset flow
+    * works before a real mail provider is configured. Codes appear in the
+    * server log; never use this in production.
+    */
+  def console[F[_]: Console: Applicative]: MailService[F, String, Unit] =
+    new MailService[F, String, Unit]:
+      def confirmationEmail(to: String, code: String): String =
+        s"To: $to — confirm your account: /confirm/$code"
+
+      def resetEmail(to: String, code: String): String =
+        s"To: $to — reset your password: /reset/$code"
+
+      def send(msg: String): EitherT[F, Throwable, Unit] =
+        EitherT.liftF(Console[F].println(s"[apollo mail] $msg"))

--- a/apollo-http4s/src/io/github/joshuakfarrar/apollo/http4s/Apollo.scala
+++ b/apollo-http4s/src/io/github/joshuakfarrar/apollo/http4s/Apollo.scala
@@ -28,12 +28,16 @@ object ApolloTemplates {
   )
 }
 
+/** When `confirmation` is `None` (the default), registration signs the
+  * user in immediately and the /confirm route is not served. Provide
+  * `Some(service)` to require e-mail confirmation before login.
+  */
 case class ApolloServices[F[_], U, I, E](
     user: UserService[F, U, I],
-    confirmation: ConfirmationService[F, U, I],
     mail: MailService[F, E, Unit],
     session: SessionService[F, U, I],
-    reset: ResetService[F, U, I]
+    reset: ResetService[F, U, I],
+    confirmation: Option[ConfirmationService[F, U, I]] = None
 )
 
 case class Apollo[F[_], U, I, E](

--- a/apollo-http4s/src/io/github/joshuakfarrar/apollo/http4s/AuthRoutes.scala
+++ b/apollo-http4s/src/io/github/joshuakfarrar/apollo/http4s/AuthRoutes.scala
@@ -91,9 +91,34 @@ object AuthRoutes:
       )
     }
 
+    def signIn(user: U): F[Response[F]] =
+      apollo.services.session.createSession(user).value.flatMap {
+        case Right(token) =>
+          SeeOther(Location(uri"/")).map(
+            _.addCookie(
+              ResponseCookie(
+                name = "session_token",
+                content = token,
+                path = Some("/"),
+                httpOnly = true,
+                secure = true,
+                sameSite = Some(SameSite.Strict)
+              )
+            )
+          )
+        case Left(error) =>
+          loginRedirectWithError(
+            s"Could not create session, you are not logged in: ${error.getMessage}"
+          )
+      }
+
     def createUser(name: String, email: String, password: String) =
       apollo.services.user.createUser(name, email, password).value.flatMap {
-        case Right(user) => createConfirmation(user)
+        case Right(user) =>
+          apollo.services.confirmation match {
+            case Some(confirmation) => createConfirmation(confirmation, user)
+            case None               => signIn(user)
+          }
         case Left(error) =>
           registrationRedirectWithError {
             error match {
@@ -109,9 +134,12 @@ object AuthRoutes:
           }
       }
 
-    def createConfirmation(user: U) = {
+    def createConfirmation(
+        confirmation: ConfirmationService[F, U, I],
+        user: U
+    ) = {
       val confirmationResult = for {
-        code <- apollo.services.confirmation.createConfirmation(user)
+        code <- confirmation.createConfirmation(user)
         _ <- apollo.services.mail.send(
           apollo.services.mail.confirmationEmail(
             implicitly[HasEmail[U]].email(user),
@@ -198,27 +226,6 @@ object AuthRoutes:
           }
       case request @ POST -> Root / "login" =>
 
-        def createSessionResponse(user: U): F[Response[F]] =
-          apollo.services.session.createSession(user).value.flatMap {
-            case Right(token) =>
-              SeeOther(Location(uri"/")).map(
-                _.addCookie(
-                  ResponseCookie(
-                    name = "session_token",
-                    content = token,
-                    path = Some("/"),
-                    httpOnly = true,
-                    secure = true,
-                    sameSite = Some(SameSite.Strict)
-                  )
-                )
-              )
-            case Left(error) =>
-              loginRedirectWithError(
-                s"Could not create session, you are not logged in: ${error.getMessage}"
-              )
-          }
-
         def extractCredentials(form: UrlForm): Option[(String, String)] =
           for {
             email <- form.getFirst("email")
@@ -247,7 +254,7 @@ object AuthRoutes:
               case Some((email, password)) =>
                 authenticateUser(email, password).value.flatMap {
                   case Right((user, authenticated)) =>
-                    if (authenticated) createSessionResponse(user)
+                    if (authenticated) signIn(user)
                     else
                       loginRedirectWithError(
                         "Could not find user with that email or password"
@@ -261,10 +268,16 @@ object AuthRoutes:
             }
           }
       case GET -> Root / "confirm" / code =>
-        apollo.services.confirmation.confirmByCode(code).value.flatMap {
-          case Some(_) => BadRequest("Unable to confirm your account")
-          case _ =>
-            loginRedirectWithSuccess("Account confirmed! You can now log in")
+        apollo.services.confirmation match {
+          case None => NotFound()
+          case Some(confirmation) =>
+            confirmation.confirmByCode(code).value.flatMap {
+              case Some(_) => BadRequest("Unable to confirm your account")
+              case _ =>
+                loginRedirectWithSuccess(
+                  "Account confirmed! You can now log in"
+                )
+            }
         }
       case request @ GET -> Root / "reset" =>
         request.attributes.lookup(apollo.config.csrfTokenKey) match {


### PR DESCRIPTION
ApolloServices.confirmation is now Option[ConfirmationService] defaulting to None. Without it, registration creates the session and signs the user in immediately, and GET /confirm/:code returns 404. Existing users opt back in with confirmation = Some(service).

MailService.console (cats-effect Console-backed) prints mail to the server log so the password-reset flow works before a real provider like Mailgun is configured.

The session-cookie logic shared by login and no-confirmation registration is hoisted into a single signIn helper in AuthRoutes.

Verified end-to-end against PostgreSQL: register -> 303 with session_token and zero confirmation rows; reset code printed via console mailer -> password change -> login with new password. The confirmation-enabled wiring compiles with the two-line config change.


Claude-Session: https://claude.ai/code/session_014LMdjJsz79AYWmX2PvhoBb