### PR TITLE
Log swallowed errors in AuthRoutes server-side

### DIFF
--- a/apollo-http4s/src/io/github/joshuakfarrar/apollo/http4s/AuthRoutes.scala
+++ b/apollo-http4s/src/io/github/joshuakfarrar/apollo/http4s/AuthRoutes.scala
@@ -10,15 +10,18 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Location
 import org.http4s.implicits.uri
 import org.http4s.twirl.*
+import org.typelevel.log4cats.LoggerFactory
 
 import java.sql.SQLException
 
 object AuthRoutes:
-  def routes[F[_]: Async, U: HasPassword: HasEmail, I, E](
+  def routes[F[_]: Async: LoggerFactory, U: HasPassword: HasEmail, I, E](
       apollo: Apollo[F, U, I, E]
   )(implicit PW: Hashable[F, String]): HttpRoutes[F] =
     val dsl = new Http4sDsl[F] {}
     import dsl.*
+
+    val log = LoggerFactory[F].getLogger
 
     def renderLogin(
         csrfToken: String,
@@ -107,7 +110,8 @@ object AuthRoutes:
             )
           )
         case Left(error) =>
-          loginRedirectWithError("Could not create session. Please try again")
+          log.warn(error)("Failed to create session") *>
+            loginRedirectWithError("Could not create session. Please try again")
       }
 
     def confirmedSignIn(user: U): F[Response[F]] =
@@ -120,10 +124,11 @@ object AuthRoutes:
               loginRedirectWithError(
                 "Please confirm your account before logging in"
               )
-            case Left(_) =>
-              loginRedirectWithError(
-                "Could not sign you in. Please try again"
-              )
+            case Left(error) =>
+              log.warn(error)("Failed to check confirmation status") *>
+                loginRedirectWithError(
+                  "Could not sign you in. Please try again"
+                )
           }
       }
 
@@ -135,18 +140,18 @@ object AuthRoutes:
             case None               => signIn(user)
           }
         case Left(error) =>
-          registrationRedirectWithError {
-            error match {
-              case sqlEx: SQLException =>
-                // SQLState 23505 is a unique-constraint violation (SQL standard)
-                sqlEx.getSQLState match {
-                  case "23505" | "23000" =>
-                    "User with that e-mail already exists"
-                  case _ =>
-                    "Could not create your account. Please try again"
-                }
-              case _ => "Could not create your account. Please try again"
-            }
+          error match {
+            // SQLState 23505 is a unique-constraint violation (SQL standard)
+            case sqlEx: SQLException
+                if sqlEx.getSQLState == "23505" || sqlEx.getSQLState == "23000" =>
+              registrationRedirectWithError(
+                "User with that e-mail already exists"
+              )
+            case _ =>
+              log.warn(error)("Failed to create user") *>
+                registrationRedirectWithError(
+                  "Could not create your account. Please try again"
+                )
           }
       }
 
@@ -166,7 +171,10 @@ object AuthRoutes:
 
       confirmationResult.value.flatMap(
         _.fold(
-          _ => registrationRedirectWithError("Failed to create new user"),
+          error =>
+            log.warn(error)(
+              "Failed to create confirmation or send confirmation e-mail"
+            ) *> registrationRedirectWithError("Failed to create new user"),
           _ =>
             loginRedirectWithSuccess(
               "Check your e-mail to confirm your account before logging in"
@@ -275,10 +283,11 @@ object AuthRoutes:
                       loginRedirectWithError(
                         "Could not find user with that email or password"
                       )
-                  case Left(_) =>
-                    loginRedirectWithError(
-                      "Could not find user with that email or password"
-                    )
+                  case Left(error) =>
+                    log.debug(error)("Login failed while fetching user") *>
+                      loginRedirectWithError(
+                        "Could not find user with that email or password"
+                      )
                 }
               case None => loginRedirectWithError("Missing email or password")
             }
@@ -386,14 +395,16 @@ object AuthRoutes:
                   )
                 }
               case Left(error) =>
-                resetCodeRedirectWithError(code)(
-                  "Failed to update password. Please try again"
-                )
+                log.warn(error)("Failed to update password") *>
+                  resetCodeRedirectWithError(code)(
+                    "Failed to update password. Please try again"
+                  )
             }
 
         apollo.services.reset.getReset(code).value.flatMap {
-          case Left(_) =>
-            resetCodeRedirectWithError(code)("Invalid or expired reset code")
+          case Left(error) =>
+            log.debug(error)("Reset code lookup failed") *>
+              resetCodeRedirectWithError(code)("Invalid or expired reset code")
           case Right(reset) =>
             request.as[UrlForm].flatMap { form =>
               extractNewPassword(form) match {

--- a/apollo-http4s/test/src/io/github/joshuakfarrar/apollo/http4s/ApolloTestKit.scala
+++ b/apollo-http4s/test/src/io/github/joshuakfarrar/apollo/http4s/ApolloTestKit.scala
@@ -8,6 +8,8 @@ import munit.CatsEffectSuite
 import org.http4s.*
 import org.http4s.implicits.*
 import org.http4s.server.middleware.CSRF
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.noop.NoOpFactory
 import org.typelevel.vault.Key
 import play.twirl.api.Html
 
@@ -25,6 +27,8 @@ case class TestUser(
 
 /** In-memory stub services and a fully wired Apollo for route tests. */
 trait ApolloTestKit extends CatsEffectSuite:
+
+  given LoggerFactory[IO] = NoOpFactory[IO]
 
   given HasId[TestUser, UUID] = _.id
   given HasEmail[TestUser] = _.email

--- a/build.mill
+++ b/build.mill
@@ -70,6 +70,7 @@ object `apollo-http4s` extends ApolloModule with TwirlModule {
     mvn"org.http4s::http4s-crypto:0.2.5-RC1",
     // no M44 build of http4s-twirl exists; M38 is the latest
     mvn"org.http4s::http4s-twirl:1.0.0-M38",
+    mvn"org.typelevel::log4cats-core:2.7.0",
     mvn"com.lihaoyi::upickle:4.1.0"
   )
 


### PR DESCRIPTION
The pre-release hardening replaced detailed user-facing error messages with generic flashes — correct for the UX, but the underlying exceptions were discarded entirely, so failures like bad DB credentials, missing schema, or mail errors were undiagnosable even from the server console (this bit a real user today: a config/database mismatch surfaced only as "Could not create your account. Please try again").

- `AuthRoutes.routes` now requires a `LoggerFactory[F]` (already on the classpath transitively via http4s-core; added as an explicit dependency) and logs each failure branch before redirecting:
  - **warn + throwable** for unexpected failures: session creation, confirmation-status checks, user creation, confirmation-mail send, password update
  - **debug** for expected ones: unknown login e-mail, invalid/expired reset code
- User-facing flash messages are unchanged. Duplicate-e-mail registrations keep their specific flash and are not logged as warnings.
- `ApolloTestKit` provides a `NoOpFactory[IO]`; the full suite (247 tasks) passes locally.

Downstream note: callers must have a `LoggerFactory[F]` in scope (e.g. `given LoggerFactory[F] = Slf4jFactory.create[F]`). A matching apollo.g8 update follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013evGpXMB49hnPF89U9ix5F

---
_Generated by [Claude Code](https://claude.ai/code/session_013evGpXMB49hnPF89U9ix5F)_